### PR TITLE
oSB postload universal support

### DIFF
--- a/_metadata
+++ b/_metadata
@@ -7,6 +7,9 @@
 	"description" : "Like walking, but better. \nTeleporting UI, reimagined by Spark Industries.",
   "steamContentId": 3291472557,
   "includes" : ["QuickbarMini", "StardustLib", "FrackinUniverse"],
+  "scripts" : {
+    "postLoad" : [ "/scripts/assets/mel_tp_postload.lua" ]
+  },
   "tags": "User Interface",
   "priority": 0
 }

--- a/objects/mel_tp.patch
+++ b/objects/mel_tp.patch
@@ -1,26 +1,17 @@
 [
     [
-        { "op" : "test", "path" : "/interactData", "value" : "/interface/warping/remoteteleporter.config" },
-
+        { "op" : "test", "path" : "/interactAction", "value" : "OpenTeleportDialog" },
+        
         { "op" : "replace", "path" : "/interactAction", "value" : "ScriptPane" },
-        { "op" : "replace", "path" : "/interactData", "value" : { 
+
+        { "op" : "move", "from" : "/interactData", "path" : "/temp" },
+        { "op" : "add", "path" : "/interactData", "value" : { 
             "gui" : {}, 
             "scripts" : ["/metagui.lua"], 
             "ui" : "sbTeleport:TeleportDialog" ,
             "data": {
-            "configPath": "/interface/warping/remoteteleporter.config" }
-        }}
-    ],
-    [
-        { "op" : "test", "path" : "/interactData", "value" : "/interface/warping/shipteleporter.config" },
-
-        { "op" : "replace", "path" : "/interactAction", "value" : "ScriptPane" },
-        { "op" : "replace", "path" : "/interactData", "value" : { 
-            "gui" : {}, 
-            "scripts" : ["/metagui.lua"], 
-            "ui" : "sbTeleport:TeleportDialog" ,
-            "data": {
-            "configPath": "/interface/warping/shipteleporter.config" }
-        }}
+            "configPath": null }
+        }},
+        { "op" : "move", "from" : "/temp", "path" : "/interactData/data/configPath" }
     ]
 ]

--- a/objects/mel_tp.patch
+++ b/objects/mel_tp.patch
@@ -1,0 +1,26 @@
+[
+    [
+        { "op" : "test", "path" : "/interactData", "value" : "/interface/warping/remoteteleporter.config" },
+
+        { "op" : "replace", "path" : "/interactAction", "value" : "ScriptPane" },
+        { "op" : "replace", "path" : "/interactData", "value" : { 
+            "gui" : {}, 
+            "scripts" : ["/metagui.lua"], 
+            "ui" : "sbTeleport:TeleportDialog" ,
+            "data": {
+            "configPath": "/interface/warping/remoteteleporter.config" }
+        }}
+    ],
+    [
+        { "op" : "test", "path" : "/interactData", "value" : "/interface/warping/shipteleporter.config" },
+
+        { "op" : "replace", "path" : "/interactAction", "value" : "ScriptPane" },
+        { "op" : "replace", "path" : "/interactData", "value" : { 
+            "gui" : {}, 
+            "scripts" : ["/metagui.lua"], 
+            "ui" : "sbTeleport:TeleportDialog" ,
+            "data": {
+            "configPath": "/interface/warping/remoteteleporter.config" }
+        }}
+    ]
+]

--- a/objects/mel_tp.patch
+++ b/objects/mel_tp.patch
@@ -20,7 +20,7 @@
             "scripts" : ["/metagui.lua"], 
             "ui" : "sbTeleport:TeleportDialog" ,
             "data": {
-            "configPath": "/interface/warping/remoteteleporter.config" }
+            "configPath": "/interface/warping/shipteleporter.config" }
         }}
     ]
 ]

--- a/scripts/assets/mel_tp_postload.lua
+++ b/scripts/assets/mel_tp_postload.lua
@@ -1,0 +1,6 @@
+-- Add object patches
+local objects = assets.byExtension("object")
+local path = "/objects/mel_tp.patch"
+for i = 1, #objects do
+  assets.patch(objects[i], path)
+end


### PR DESCRIPTION
Using an oSB postload script, I added universal support to any object that uses `remoteteleporter.config` or `shipteleporter.config`. This script will only be loaded when running oSB is enabled, and won't cause any issues if not running oSB.